### PR TITLE
Reduce issue template complexity

### DIFF
--- a/.github/ISSUE_TEMPLATE/01-user_story.md
+++ b/.github/ISSUE_TEMPLATE/01-user_story.md
@@ -17,25 +17,8 @@ assignees: ''
 
 ## Confirmation
 
-*List one or more acceptance criteria with which to confirm that the problem has been solved.*
-
-### QA Hints
-
-*If necessary, give some hints for the QA how to setup the scenario or how to check the points of the confirmation.*
+## Links
 
 # Development
 
-## Links
-
-*Any links that help explain the problem or the desired solution, e.g.:*
-- *Customer Tickets*
-- *External Specifications*
-- *Documentation*
-
-## Hints
-
-*Any tips for the developer how to implement the solution.*
-
 ## Progress
-
-- *List all pull requests that created to implement the solution*

--- a/.github/ISSUE_TEMPLATE/02-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.md
@@ -9,48 +9,18 @@ assignees: ''
 
 # Bug Report
 
-*A clear and concise description of what the bug is.*
+*Start with a clear and concise description of what the bug is. Then try to fill out the points below.*
 
 ## Steps To Reproduce
-
-*Steps to reproduce the behavior:*
 
 1. ...
 
 ## Expected behavior
 
-*A clear and concise description of what you expected to happen.*
-
 ## Screenshots
 
-*If applicable, add screenshots to help explain your problem.*
-
-## System Environment and Configuration
-
-*A description of the system the error appeared on with any details of the environment and/or configuration that may be helpful.*
-
 ## Links
-
-- *Links to customer tickets.*
-- *Any links to external content that is relevant to the bug, e.g. feature or interface documentation.*
-
-## Additional context
-
-*Add any other context about the problem here.*
 
 # Development
 
-## Links
-
-*Any links that help explain the problem or the desired solution, e.g.:*
-- *Customer Tickets*
-- *External Specifications*
-- *Documentation*
-
-## Hints
-
-*Any tips for the developer how to implement the solution.*
-
 ## Progress
-
-- *List all pull requests that created to implement the solution*

--- a/.github/ISSUE_TEMPLATE/02-bug_report.md
+++ b/.github/ISSUE_TEMPLATE/02-bug_report.md
@@ -9,7 +9,7 @@ assignees: ''
 
 # Bug Report
 
-*Start with a clear and concise description of what the bug is. Then try to fill out the points below.*
+*Start with a clear and concise description of what the bug is, i.e. point out the unwanted actual behaviour. Then try to fill out the points below.*
 
 ## Steps To Reproduce
 


### PR DESCRIPTION
Cut down on the number of sections of the user stories. This should increase focus on the most important points. Remove all the instructions how to fill out the template except the first (per template). The headings should be clear enough. The first instruction remains as a starting point.